### PR TITLE
Add joystream network with prefix 126

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ss58-registry"
 authors = ["Parity Technologies <admin@parity.io>"]
-version = "1.22.0"
+version = "1.23.0"
 edition = "2021"
 description = "Registry of known SS58 address types"
 license = "Apache-2.0"

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -668,6 +668,15 @@
       "website": "https://invarch.network"
     },
     {
+      "prefix": 126,
+      "network": "joystream",
+      "displayName": "Joystream",
+      "symbols": ["JOY"],
+      "decimals": [10],
+      "standardAccount": "*25519",
+      "website": "https://www.joystream.org"
+    },
+    {
       "prefix": 128,
       "network": "clover",
       "displayName": "Clover Finance",


### PR DESCRIPTION
AFAICT, we need to make a PR to [parity](https://github.com/paritytech/ss58-registry) from our own fork in order to get this reserved.

See issues [3389](https://github.com/Joystream/joystream/issues/3389), [181](https://github.com/Joystream/joystream/issues/181) and [2531](https://github.com/Joystream/pioneer/issues/2531) for context.

In the former, @Lezek123 confirms we'll not only get a `j` but also `4` as an unintended bonus for `j4` as prefix.
